### PR TITLE
fix CMake based build

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -97,12 +97,9 @@ class SDLConan(ConanFile):
         """ Define your conan structure: headers, libs and data. After building your
             project, this method is called to create a defined structure:
         """
-        # Duplicate headers, SDL2/SDL.h and SDL.h are commonly used... fucking mess
+
         self.copy(pattern="*.h", dst="include/SDL2", src="%s/_build/include" % self.folder, keep_path=False)
         self.copy(pattern="*.h", dst="include/SDL2", src="%s/include" % self.folder, keep_path=False)
-        
-        self.copy(pattern="*.h", dst="include", src="%s/_build/include" % self.folder, keep_path=False)
-        self.copy(pattern="*.h", dst="include", src="%s/include" % self.folder, keep_path=False)
         
         # Win
         if self.options.shared:
@@ -120,7 +117,8 @@ class SDLConan(ConanFile):
                 self.copy(pattern="*.dylib*", dst="lib", src="%s/build/.libs/" % self.folder, keep_path=False)
 
     def package_info(self):  
-                
+        
+        self.cpp_info.includedirs += ["include/SDL2"]
         self.cpp_info.libs = ["SDL2"]
           
         if self.settings.os == "Windows":

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ from conans import CMake, ConfigureEnvironment
 
 class SDLConan(ConanFile):
     name = "SDL2"
-    version = "2.0.4"
+    version = "2.0.5"
     folder = "SDL2-%s" % version
     settings = "os", "arch", "compiler", "build_type"
     options = {"directx": [True, False], "shared": [True, False], "fPIC": [True, False]}


### PR DESCRIPTION
Currently i think only the usual make procedure worked.
This patch makes it work under VS 15 based on different args passed to sdl2s cmake.

Could you maybe try whether this also works under linux? (And maybe we should throw out the makefile modification, so we need to support just one build procedure?)
I've uploaded a test for this in SDL2/2.0.5@a_teammate/testing