### PR TITLE
fixed win shared

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,5 @@
 from conans import ConanFile
 from conans.tools import download, unzip, replace_in_file
-import os
 import shutil
 from conans import CMake, ConfigureEnvironment
 
@@ -87,8 +86,9 @@ class SDLConan(ConanFile):
          # Build
         directx_def = "-DDIRECTX=ON" if self.options.directx else "-DDIRECTX=OFF"
         static_run = "-DSDL_SHARED_ENABLED_BY_DEFAULT=%s" % ("ON" if self.options.shared else "OFF")
+        static_run += " -DSDL_STATIC=%s" % ("OFF" if self.options.shared else "ON")
         self.run("cd %s &&  mkdir _build" % self.folder)
-        configure_command = 'cd %s/_build && cmake .. %s %s %s -DLIBC=ON' % (self.folder, cmake.command_line, directx_def, static_run)
+        configure_command = 'cd %s/_build && cmake .. %s %s %s -DLIBC=OFF' % (self.folder, cmake.command_line, directx_def, static_run)
         self.output.warn("Configure with: %s" % configure_command)
         self.run(configure_command)
         self.run("cd %s/_build && cmake --build . %s" % (self.folder, cmake.build_config))


### PR DESCRIPTION
Could address: https://github.com/lasote/conan-sdl2/issues/11

Not sure what LIBC=ON does, but removing it allows it to work on windows for shared.