### PR TITLE
get rid of ConfigureEnvironment

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -66,7 +66,7 @@ class SDLConan(ConanFile):
         if self.settings.os == "Macos":
             vars["CC"] = "{}/build-scripts/gcc-fat.sh".format(self.folder)
         with tools.environment_append(vars):
-            self.run('cd %s && ./configure' % (self.folder))
+            self.run('cd %s && ./configure --enable-mir-shared=no' % (self.folder))
             self.run("cd %s && make" % (self.folder))
 
     def build_with_cmake(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,6 @@
 from conans import ConanFile, tools
 from conans.tools import download, unzip, replace_in_file
-import shutil
+import shutil, os
 from conans import CMake, AutoToolsBuildEnvironment
 
 class SDLConan(ConanFile):
@@ -108,6 +108,7 @@ class SDLConan(ConanFile):
 
         self.cpp_info.includedirs += ["include/SDL2"]
         self.cpp_info.libs = ["SDL2"]
+        self.env_info.SDL2_CONFIG = os.path.join(self.package_folder, "lib")
 
         if self.settings.os == "Windows":
             self.cpp_info.libs.append("OpenGL32")

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,8 +20,8 @@ class DefaultNameConan(ConanFile):
     generators = ["cmake", "gcc"] # Generates conanbuildinfo.gcc with all deps information
 
     def build(self):
-        cmake = CMake(self.settings)
-        self.run('cmake %s %s' % (self.conanfile_directory, cmake.command_line))
+        cmake = CMake(self)
+        self.run('cmake %s %s' % (self.source_folder, cmake.command_line))
         self.run("cmake --build . %s" % cmake.build_config)
 
     def imports(self):


### PR DESCRIPTION
to make it compatible with conan 0.30

---

you might want to skip the change in line 92/79: `configure_command = 'cd %s/_build && cmake .. %s %s %s -DLIBC=ON' % (self.folder, cmake.command_line, directx_def, static_run)`

I dont remember why we had this LIBC ON, while you didn't. iirc it had something to do with working for shared libs vs working for x86.

I see that you are really busy these days making conan 1.0, props for that :1st_place_medal: 